### PR TITLE
Make no-arg mutations comply with GraphQL spec

### DIFF
--- a/src/main/edn_query_language/eql_graphql.cljc
+++ b/src/main/edn_query_language/eql_graphql.cljc
@@ -118,7 +118,7 @@
                                 children)
                             (remove (comp #{'*} :key)))]
           (str (pad-depth depth) (js-name dispatch-key)
-               (params->graphql (dissoc params ::mutate-join) js-name)
+               (if (seq params) (params->graphql (dissoc params ::mutate-join) js-name))
                (if (seq children)
                  (str
                    " {\n"

--- a/test/edn_query_language/eql_graphql_test.cljc
+++ b/test/edn_query_language/eql_graphql_test.cljc
@@ -100,6 +100,9 @@
     (is (= (query->graphql '[(call {:enum HEY})])
            "mutation { call(enum: HEY)}"))
 
+    (is (= (query->graphql '[(call)])
+           "mutation { call}"))
+
     (is (= (query->graphql '[{(call {:param "value" :item/value 42}) [:id :foo]}])
            "mutation { call(param: \"value\", value: 42) { id foo } }"))
 


### PR DESCRIPTION
It looks like `eql-graphql`'s handling of mutations with no arguments does not comply with GraphQL spec.

Currently empty argument brackets are being generated when no arguments are supplied.
```clojure
$ (query->graphql '[(call)])
"mutation { call()}"
```

Here's what the spec says:

Arguments definition http://spec.graphql.org/June2018/#sec-Language.Arguments, note the `list` bit

> Arguments<sub>[Const]</sub> :
> ( Argument<sub>[?Const]list</sub> )

Definition of `list` further down http://spec.graphql.org/June2018/#sec-Grammar-Notation (emphasis mine)
> A subscript suffix “Symbol<sub>list</sub>” is shorthand for a list of **one or more** of that symbol.


If I'm reading it right, this means empty args should just be omitted. This also seems to be the conclusion of the `graphql-js` maintainers https://github.com/graphql/graphql-js/issues/1860

Probably worth mentioning that `lacinia` won't accept empty args brackets either, which is what led the discovery of this bug.

This MR fixes the issue and provides a test case.