### PR TITLE
Add support to babashka.json

### DIFF
--- a/src/main/edn_query_language/eql_graphql.cljc
+++ b/src/main/edn_query_language/eql_graphql.cljc
@@ -1,7 +1,8 @@
 (ns edn-query-language.eql-graphql
   "Tools to convert the EQL expressions to GraphQL strings."
   (:require
-    #?(:clj [clojure.data.json :as json])
+    #?(:bb  [babashka.json :as json]
+       :clj [clojure.data.json :as json])
     [clojure.string :as str]
     [edn-query-language.core :as eql]))
 


### PR DESCRIPTION
`org.clojure/data.json {:mvn/version "0.2.6"}` uses `definterface` now that is not present on babashka